### PR TITLE
fix: Prevent crash on TrackingScreen during log creation

### DIFF
--- a/src/screens/TrackingScreen.tsx
+++ b/src/screens/TrackingScreen.tsx
@@ -167,7 +167,13 @@ const TrackingScreen = () => {
           const fetchedLogs: AnyLog[] = snapshot.docs.map(doc => ({ id: doc.id, category: collectionName.replace('Logs', '') as Category, ...doc.data() } as AnyLog));
           setLogs(prevLogs => {
             const otherLogs = prevLogs.filter(log => log.category !== collectionName.replace('Logs', ''));
-            return [...otherLogs, ...fetchedLogs].sort((a, b) => b.createdAt.toMillis() - a.createdAt.toMillis());
+            // JULES: Added null-safe sorting to prevent crashes from pending server timestamps.
+            // When a new log is created, `createdAt` can be temporarily null in the local snapshot.
+            return [...otherLogs, ...fetchedLogs].sort((a, b) => {
+              const timeA = a.createdAt?.toMillis() || 0;
+              const timeB = b.createdAt?.toMillis() || 0;
+              return timeB - timeA;
+            });
           });
           setLoading(false);
         }, error => {


### PR DESCRIPTION
This commit resolves a TypeError, "Cannot read property 'toMillis' of null," that occurred in the TrackingScreen.

The error was caused by the log sorting function attempting to access the `toMillis()` method on a `createdAt` field that was temporarily null. This can happen with Firestore's `onSnapshot` listener, which provides an immediate local snapshot of a write before the server has assigned the final `serverTimestamp`.

The sorting logic has been made null-safe using optional chaining to prevent the crash and ensure the UI remains stable while waiting for the server-confirmed data.