### PR TITLE
fix(navigation): Correctly display header back button in nested stack

### DIFF
--- a/src/navigation/GuidesStackNavigator.tsx
+++ b/src/navigation/GuidesStackNavigator.tsx
@@ -48,6 +48,7 @@ const GuidesStackNavigator = (): React.JSX.Element => {
         title: 'BabyWise',
         headerTitleAlign: 'center',
         headerRight: () => <HeaderRightMenu />,
+        headerLeft: () => <HeaderLeftBack />,
       }}
       // The first screen to be displayed in this stack.
       initialRouteName="GuidesList">
@@ -55,15 +56,12 @@ const GuidesStackNavigator = (): React.JSX.Element => {
         name="GuidesList"
         component={GuidesScreen}
         // GuidesList is the top level, so it shouldn't have a back button.
-        // We leave headerLeft to its default state.
+        // The visibility of the back button is now controlled by the component itself.
       />
       <Stack.Screen
         name="GuideDetail"
         component={GuideDetailScreen}
-        options={{
-          // Only show the back button on the detail screen.
-          headerLeft: () => <HeaderLeftBack />,
-        }}
+        // No specific options needed here anymore for the header.
       />
     </Stack.Navigator>
   );


### PR DESCRIPTION
Moved the `headerLeft` configuration from the `GuideDetailScreen`'s options to the parent `GuidesStackNavigator`'s `screenOptions`.

This resolves an issue where the custom back button would not render on the nested detail screen. By defining `headerLeft` at the navigator level, we ensure React Navigation consistently allocates space and renders the component. The component's internal `canGoBack()` check correctly handles its visibility, showing it only on detail screens and hiding it on the initial list screen.